### PR TITLE
COA-452 | OffsetDateTime | Add Avro ability for OffsetDateTime

### DIFF
--- a/avro4s-core/src/main/scala/com/cognitops/avro4s/CustomDecoder.scala
+++ b/avro4s-core/src/main/scala/com/cognitops/avro4s/CustomDecoder.scala
@@ -1,0 +1,19 @@
+package com.cognitops.avro4s
+
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+
+import com.sksamuel.avro4s.{Decoder, FieldMapper}
+import org.apache.avro.Schema
+
+/**
+ * Custom Cognitops Decoders
+ */
+object CustomDecoder {
+
+  implicit object OffsetDateTimeDecoder extends Decoder[OffsetDateTime] {
+    override def decode(value: Any, schema: Schema, fieldMapper: FieldMapper) =
+      OffsetDateTime.parse(value.toString, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+  }
+
+}

--- a/avro4s-core/src/main/scala/com/cognitops/avro4s/CustomEncoder.scala
+++ b/avro4s-core/src/main/scala/com/cognitops/avro4s/CustomEncoder.scala
@@ -1,0 +1,19 @@
+package com.cognitops.avro4s
+
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+
+import com.sksamuel.avro4s.{Encoder, FieldMapper}
+import org.apache.avro.Schema
+
+/**
+ * Custom Cognitops Encoders
+ */
+object CustomEncoder {
+
+  implicit object OffsetDateTimeEncoder extends Encoder[OffsetDateTime] {
+    override def encode(value: OffsetDateTime, schema: Schema, fieldMapper: FieldMapper) =
+      value.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+  }
+
+}

--- a/avro4s-core/src/main/scala/com/cognitops/avro4s/CustomLogicalTypes.scala
+++ b/avro4s-core/src/main/scala/com/cognitops/avro4s/CustomLogicalTypes.scala
@@ -1,0 +1,23 @@
+package com.cognitops.avro4s
+
+import org.apache.avro.{LogicalType, Schema}
+
+/**
+ * Custom Cognitops LogicalTypes
+ */
+object CustomLogicalTypes {
+
+  implicit object OffsetDateTimeLogicalType extends LogicalType("iso-datetime with offset") {
+
+    override def validate(schema: Schema): Unit = {
+      super.validate(schema)
+      if (schema.getType != Schema.Type.STRING) {
+        throw new IllegalArgumentException("Logical type iso-datetime with offset must be backed by String")
+      }
+    }
+
+  }
+
+}
+
+

--- a/avro4s-core/src/main/scala/com/cognitops/avro4s/CustomSchemaFor.scala
+++ b/avro4s-core/src/main/scala/com/cognitops/avro4s/CustomSchemaFor.scala
@@ -1,0 +1,18 @@
+package com.cognitops.avro4s
+
+import java.time.OffsetDateTime
+
+import com.cognitops.avro4s.CustomLogicalTypes.OffsetDateTimeLogicalType
+import com.sksamuel.avro4s.{FieldMapper, SchemaFor}
+import org.apache.avro.SchemaBuilder
+
+/**
+ * Custom Cognitops schemas
+ */
+object CustomSchemaFor {
+
+  implicit object OffsetDateTimeSchemaFor extends SchemaFor[OffsetDateTime] {
+    override def schema(fieldMapper: FieldMapper) = OffsetDateTimeLogicalType.addToSchema(SchemaBuilder.builder().stringType())
+  }
+
+}

--- a/avro4s-core/src/test/resources/cognitops/offsetdatetime_schema.json
+++ b/avro4s-core/src/test/resources/cognitops/offsetdatetime_schema.json
@@ -1,0 +1,1 @@
+{"type":"string","logicalType":"iso-datetime with offset"}

--- a/avro4s-core/src/test/scala/com/cognitops/avro4s/OffsetDateTimeTest.scala
+++ b/avro4s-core/src/test/scala/com/cognitops/avro4s/OffsetDateTimeTest.scala
@@ -1,0 +1,78 @@
+package com.cognitops.avro4s
+
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+
+import com.sksamuel.avro4s.{AvroSchema, Decoder, DefaultFieldMapper, Encoder, SchemaFor}
+import org.scalatest.{Matchers, WordSpec}
+
+
+class OffsetDateTimeTest extends WordSpec with Matchers {
+
+  "OffsetDateTime" must {
+
+    import com.cognitops.avro4s.CustomSchemaFor._
+    import com.cognitops.avro4s.CustomEncoder._
+    import com.cognitops.avro4s.CustomDecoder._
+
+    val NOW = OffsetDateTime.now()
+    val MAX = OffsetDateTime.MAX
+    val MIN = OffsetDateTime.MIN
+
+    "generate a schema with a logical type backed by a string" in {
+      val schema = AvroSchema[OffsetDateTime]
+      val expected = new org.apache.avro.Schema.Parser().parse(this.getClass.getResourceAsStream("/cognitops/offsetdatetime_schema.json"))
+      schema shouldBe expected
+    }
+
+    "encode to an iso formatted String" in {
+      def testEncode(datetime: OffsetDateTime): Unit = {
+        val encoded = Encoder[OffsetDateTime].encode(
+          datetime,
+          AvroSchema[OffsetDateTime],
+          DefaultFieldMapper
+        )
+        encoded shouldBe datetime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+      }
+      testEncode(NOW)
+      testEncode(MAX)
+      testEncode(MIN)
+    }
+
+    "decode an iso formatted String to an equivalent OffsetDatetime object" in {
+      def testDecode(datetime: OffsetDateTime): Unit = {
+        val dateTimeString = datetime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        val decoder = Decoder[OffsetDateTime].decode(
+          dateTimeString,
+          AvroSchema[OffsetDateTime],
+          DefaultFieldMapper
+        )
+        decoder shouldBe datetime
+      }
+      testDecode(NOW)
+      testDecode(MAX)
+      testDecode(MIN)
+    }
+
+    "round trip encode and decode into an equivalent object" in {
+      def testRoundTrip(datetime: OffsetDateTime): Unit = {
+        val encoded = Encoder[OffsetDateTime].encode(
+          datetime,
+          AvroSchema[OffsetDateTime],
+          DefaultFieldMapper
+        )
+        val decoded = Decoder[OffsetDateTime].decode(
+          encoded,
+          AvroSchema[OffsetDateTime],
+          DefaultFieldMapper
+        )
+        decoded shouldBe datetime
+      }
+      testRoundTrip(NOW)
+      testRoundTrip(MAX)
+      testRoundTrip(MIN)
+    }
+
+  }
+
+}


### PR DESCRIPTION
Added custom LogicalType, SchemaFor, Encoder, and Decoder to handle OffsetDateTime objects. Avro only has built in types to hand datetimes that are UTC zoned, therefore we had to add the ability to handle time zone offsets.